### PR TITLE
Unpin Qt/PyQt

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 3b20d7e4666222200d9ba693b8a665a2
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
   entry_points:
     - glue = glue.main:main
@@ -23,7 +23,7 @@ requirements:
   build:
     - python
     - setuptools
-    - pyqt 4.11.*
+    - pyqt 4.11.*|5.6.*
 
   run:
 
@@ -45,7 +45,8 @@ requirements:
     - xlrd >=1.0
     - h5py >=2.4
     - setuptools >=1.0
-    - pyqt 4.11.*
+    - pyqt 4.11.*|5.6.*
+
 
     # Optional dependencies (defined in ``extras_require``)
     - scipy


### PR DESCRIPTION
Don't pin PyQt since things should now work properly with Qt5 from defaults (following discussion with @ocefpaf)