### PR TITLE
Don't include PyQt as a build-time dependency

### DIFF
--- a/recipe/disable_qt_check.patch
+++ b/recipe/disable_qt_check.patch
@@ -1,0 +1,23 @@
+diff --git a/setup.py b/setup.py
+index fc277487..881325bd 100755
+--- a/setup.py
++++ b/setup.py
+@@ -73,18 +73,6 @@ glue-deps = glue._deps:main
+ glue = glue.main:main
+ """
+ 
+-# Glue can work with PyQt5 and PySide2. We can't add them to install_requires
+-# because they aren't on PyPI but we can check here that one of them is
+-# installed.
+-try:
+-    import PyQt5  # noqa
+-except ImportError:
+-    try:
+-        import PySide2  # noqa
+-    except ImportError:
+-        print("Glue requires PyQt5 or PySide2 to be installed")
+-        sys.exit(1)
+-
+ install_requires = ['numpy>=1.9',
+                     'pandas>=0.14',
+                     'astropy>=1.3',

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,13 +5,20 @@ package:
   version: {{version}}
 
 source:
+
   fn: glue-core-{{version}}.tar.gz
   url: https://pypi.io/packages/source/g/glue-core/glue-core-{{version}}.tar.gz
   sha256: 9a52bdbfac355579caed2735ba7644113d861ce2c4e084830c99a69374043495
 
+  # The default setup.py includes a hard-coded check that PyQt is present but
+  # since we don't want to list it as a build-time dependency (since conda then
+  # restricts the versions too much)
+  patches:
+    - disable_qt_check.patch
+
 build:
-  number: 0
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  number: 1
+  script: python -m pip install --no-deps --ignore-installed .
   entry_points:
     - glue = glue.main:main
     - glue-config = glue.config_gen:main
@@ -22,8 +29,7 @@ requirements:
 
   build:
     - python
-    - setuptools
-    - pyqt 5.6.*
+    - pip
 
   run:
 
@@ -48,7 +54,6 @@ requirements:
     - mpl-scatter-density >=0.3
     - setuptools >=1.0
     - pyqt 5.6.*
-
 
     # Optional dependencies (defined in ``extras_require``)
     - scipy


### PR DESCRIPTION
Otherwise conda adds pinning for PyQt that may not be compatible with the one we specified